### PR TITLE
修正 role:scripts 安裝的方式

### DIFF
--- a/scripts/onion
+++ b/scripts/onion
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  *
  */
-define('ROOT', dirname(__DIR__) );
-require ROOT . '/vendor/pear/Universal/ClassLoader/SplClassLoader.php';
-$classLoader = new \Universal\ClassLoader\SplClassLoader(array( 
-    'Onion' => ROOT . '/src',
-    'CurlKit' => ROOT . '/src',
-    'CLIFramework' => ROOT . '/vendor/pear',
-    'PEARX' => ROOT . '/vendor/pear',
-    'GetOptionKit' =>  ROOT . '/vendor/pear',
+define('BASE_PATH', realpath(__DIR__ . '/../'));
+require BASE_PATH . '/vendor/pear/Universal/ClassLoader/SplClassLoader.php';
+$classLoader = new \Universal\ClassLoader\SplClassLoader(array(
+    'Onion' => BASE_PATH . '/src',
+    'CurlKit' => BASE_PATH . '/src',
+    'CLIFramework' => BASE_PATH . '/vendor/pear',
+    'PEARX' => BASE_PATH . '/vendor/pear',
+    'GetOptionKit' => BASE_PATH . '/vendor/pear',
 ));
 $classLoader->useIncludePath(true);
 $classLoader->register();

--- a/src/Onion/Pear/PackageXmlGenerator.php
+++ b/src/Onion/Pear/PackageXmlGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Onion package.
  *
@@ -8,7 +9,9 @@
  * file that was distributed with this source code.
  *
  */
+
 namespace Onion\Pear;
+
 use SimpleXMLElement;
 use DOMDocument;
 use RecursiveDirectoryIterator;
@@ -26,16 +29,16 @@ use SplFileInfo;
  *      $pkgxml->setUseDefault(true);
  *      $pkgxml->setReformat(true);
  *      $pkgxml->generate('package.xml');
- * 
+ *
  */
-class PackageXmlGenerator
-    implements LoggableInterface
+class PackageXmlGenerator implements LoggableInterface
 {
+
     public $package;
     public $reformat = true;
     public $useDefault = true;
 
-    function __construct( $package )
+    function __construct($package)
     {
         $this->package = $package;
     }
@@ -50,7 +53,7 @@ class PackageXmlGenerator
         $this->reformat = $bool;
     }
 
-    function setLogger( \CLIFramework\Logger $logger)
+    function setLogger(\CLIFramework\Logger $logger)
     {
         $this->logger = $logger;
     }
@@ -60,69 +63,68 @@ class PackageXmlGenerator
         return $this->logger;
     }
 
-
     function generate()
     {
-		$logger = $this->getLogger();
-		try {
-			$package = $this->package;
-			$config = $this->package->config;
+        $logger = $this->getLogger();
+        try {
+            $package = $this->package;
+            $config = $this->package->config;
 
-            $xmlstr =<<<XML
+            $xmlstr = <<<XML
 <package packagerversion="1.4.10" version="2.0"
-		xmlns="http://pear.php.net/dtd/package-2.0"
-		xmlns:tasks="http://pear.php.net/dtd/tasks-1.0"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0
-							http://pear.php.net/dtd/tasks-1.0.xsd
-							http://pear.php.net/dtd/package-2.0
-							http://pear.php.net/dtd/package-2.0.xsd">
+    xmlns="http://pear.php.net/dtd/package-2.0"
+    xmlns:tasks="http://pear.php.net/dtd/tasks-1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0
+              http://pear.php.net/dtd/tasks-1.0.xsd
+              http://pear.php.net/dtd/package-2.0
+              http://pear.php.net/dtd/package-2.0.xsd">
 </package>
 XML;
 
-            $xml              = new SimpleXMLElement($xmlstr); 
-            $xml->name        = $config->{ 'package.name' };
-            $xml->channel     = $config->{ 'package.channel' };
-            $xml->summary     = $config->{ 'package.summary' };
+            $xml = new SimpleXMLElement($xmlstr);
+            $xml->name = $config->{ 'package.name' };
+            $xml->channel = $config->{ 'package.channel' };
+            $xml->summary = $config->{ 'package.summary' };
             $xml->description = $config->{ 'package.desc' };
 
-            if( $config->has('package.extends') )
+            if ($config->has('package.extends'))
                 $xml->extends = $config->get('package.extends');
 
-            $author_data = SpecUtils::parseAuthor( $config->get('package.author') );
+            $author_data = SpecUtils::parseAuthor($config->get('package.author'));
             $lead = $xml->addChild('lead');
-            foreach( $author_data as $k => $v )
+            foreach ($author_data as $k => $v)
                 $lead->$k = $v;
             $lead->active = 'yes';
 
-            if( $config->has('package.authors') ) {
-                foreach( $config->get('package.authors') as $author ) {
+            if ($config->has('package.authors')) {
+                foreach ($config->get('package.authors') as $author) {
                     $lead = $xml->addChild('lead');
-                    $data =  SpecUtils::parseAuthor( $author );
-                    foreach( $data as $k => $v )
+                    $data = SpecUtils::parseAuthor($author);
+                    foreach ($data as $k => $v)
                         $lead->$k = $v;
                     $lead->active = 'yes';
                 }
             }
 
-            $xml->date        = date('Y-m-d');
-            $xml->time        = strftime('%T');
+            $xml->date = date('Y-m-d');
+            $xml->time = strftime('%T');
 
-			// add version block
-            $version          = $xml->addChild('version');
+            // add version block
+            $version = $xml->addChild('version');
             $version->release = $config->get('package.version');
-            $version->api     = $config->get('package.version.api');
+            $version->api = $config->get('package.version.api');
 
-			// stability block
-            $stability        = $xml->addChild('stability');
+            // stability block
+            $stability = $xml->addChild('stability');
             $stability->release = $config->get('package.stability.release');  # XXX: detect from version number.
-            $stability->api     = $config->get('package.stability.api');
+            $stability->api = $config->get('package.stability.api');
 
 
-			// XXX: license, support license url later
-            $xml->license     = $config->get('package.license');
+            // XXX: license, support license url later
+            $xml->license = $config->get('package.license');
 
-            $xml->notes       = $config->get('package.notes') ?: '-';
+            $xml->notes = $config->get('package.notes') ? : '-';
 
 
 
@@ -130,175 +132,163 @@ XML;
             // build content sections
             $logger->info('Building contents section...');
 
-			$roles = $package->getDefaultStructureConfig();
+            $roles = $package->getDefaultStructureConfig();
             // default roles
             $filelist = array();
-			foreach( $roles as $role => $paths ) {
-				foreach( $paths as $path ) {
-                    $logger->debug( "treat path \"$path\" as \"$role\" role" , 1 );
-                    $files = $this->addPathByRole( $path, $role );
-                    $filelist = array_merge( $filelist, $files);
-				}
-			}
+            foreach ($roles as $role => $paths) {
+                foreach ($paths as $path) {
+                    $logger->debug("treat path \"$path\" as \"$role\" role", 1);
+                    $files = $this->addPathByRole($path, $role);
+                    $filelist = array_merge($filelist, $files);
+                }
+            }
 
-			$customRoles = $config->get('roles');
-            if( $customRoles ) {
-                foreach( $customRoles as $pattern => $role ) {
+            $customRoles = $config->get('roles');
+            if ($customRoles) {
+                foreach ($customRoles as $pattern => $role) {
                     if (in_array($pattern, $roles['test'])) {
                         continue;
                     }
-                    $logger->debug( "treat \"$pattern\" as \"$role\" role" , 1 );
-                    $files = $this->addPathByRole( $pattern , $role );
-                    $filelist = array_merge( $filelist, $files);
+                    $logger->debug("treat \"$pattern\" as \"$role\" role", 1);
+                    $files = $this->addPathByRole($pattern, $role);
+                    $filelist = array_merge($filelist, $files);
                 }
             }
 
             $contentsXml = $xml->addChild('contents');
             $dir = $contentsXml->addChild('dir');
-            $dir->addAttribute('name','/');
-            foreach( $filelist as $contentFile ) { // ContentFile class
+            $dir->addAttribute('name', '/');
+            foreach ($filelist as $contentFile) { // ContentFile class
                 $file = $dir->addChild('file');
-                $file->addAttribute( 'name'       , $contentFile->file );
-                $file->addAttribute( 'role'       , $contentFile->role );
-                $file->addAttribute( 'md5sum'     , $contentFile->md5sum );
+                $file->addAttribute('name', $contentFile->file);
+                $file->addAttribute('role', $contentFile->role);
+                $file->addAttribute('md5sum', $contentFile->md5sum);
             }
 
-			// dependencies section
+            // dependencies section
             $logger->info('Building dependencies section...');
 
             $deps = $xml->addChild('dependencies');
-			$required = $deps->addChild('required');
+            $required = $deps->addChild('required');
 
-			// build required dependencies
-			foreach( $package->deps as $dep ) {
-				/*
-				<package>
-					<name>GetOptionKit</name>
-					<channel>pear.corneltek.com</channel>
-					<min>0.0.2</min>
-				</package>
-				 */
+            // build required dependencies
+            foreach ($package->deps as $dep) {
+                /*
+                  <package>
+                  <name>GetOptionKit</name>
+                  <channel>pear.corneltek.com</channel>
+                  <min>0.0.2</min>
+                  </package>
+                 */
 
-                $logger->debug2( sprintf("dependency %-10s %s", $dep['type'], $dep['name']) , 1);
+                $logger->debug2(sprintf("dependency %-10s %s", $dep['type'], $dep['name']), 1);
 
-				// only PEAR packages
-				switch( $dep['type'] ) {
+                // only PEAR packages
+                switch ($dep['type']) {
 
-                case 'core':
-                    $name = $dep['name'];
-                    $depCore = $required->addChild($name);
-					if( $dep['version'] ) {
-						foreach( $dep['version'] as $k => $v ) {
-							$depCore->addChild( $k , $v );
-						}
-					}
-                    break;
+                    case 'core':
+                        $name = $dep['name'];
+                        $depCore = $required->addChild($name);
+                        if ($dep['version']) {
+                            foreach ($dep['version'] as $k => $v) {
+                                $depCore->addChild($k, $v);
+                            }
+                        }
+                        break;
 
-				case 'pear':
-					$depPackage = $required->addChild('package');
-					$depPackage->addChild('name', $dep['name'] );
+                    case 'pear':
+                        $depPackage = $required->addChild('package');
+                        $depPackage->addChild('name', $dep['name']);
 
-					if( $dep['resource']['type'] == 'channel' ) {
-						$channelHost = $dep['resource']['channel'];
-						$depPackage->addChild('channel', $channelHost );
-					}
-					if( $dep['version'] ) {
-						foreach( $dep['version'] as $k => $v ) {
-							$depPackage->addChild( $k , $v );
-						}
-					}
-					break;
-				case 'extension':
-					$depExtension = $required->addChild('extension');
-					$depExtension->addChild('name', $dep['name'] );
-					if( $dep['version'] ) {
-						foreach( $dep['version'] as $k => $v ) {
-							$depExtension->addChild( $k , $v );
-						}
-					}
-					break;
-				}
-			}
-
-
-			// xxx: support optional dependencies
-
-			// xxx: support optional group dependencies
-
-
-			// phprelease sections
-            $logger->info( "Building phprelease section..." );
-            {
-                $phprelease = $xml->addChild('phprelease');
-                $filelistNode = $phprelease->addChild('filelist');
-                foreach( $filelist as $contentFile ) { // ContentFile class
-                    $file = $filelistNode->addChild('install');
-                    $file->addAttribute( 'name'       , $contentFile->file );
-                    $file->addAttribute( 'as'         , $contentFile->installAs );
+                        if ($dep['resource']['type'] == 'channel') {
+                            $channelHost = $dep['resource']['channel'];
+                            $depPackage->addChild('channel', $channelHost);
+                        }
+                        if ($dep['version']) {
+                            foreach ($dep['version'] as $k => $v) {
+                                $depPackage->addChild($k, $v);
+                            }
+                        }
+                        break;
+                    case 'extension':
+                        $depExtension = $required->addChild('extension');
+                        $depExtension->addChild('name', $dep['name']);
+                        if ($dep['version']) {
+                            foreach ($dep['version'] as $k => $v) {
+                                $depExtension->addChild($k, $v);
+                            }
+                        }
+                        break;
                 }
             }
 
 
-		} catch ( Exception $e ) {
-            $logger->error( $e->getMessage() );
-			exit(1);
-		}
+            // xxx: support optional dependencies
+            // xxx: support optional group dependencies
+            // phprelease sections
+            $logger->info("Building phprelease section..."); {
+                $phprelease = $xml->addChild('phprelease');
+                $filelistNode = $phprelease->addChild('filelist');
+                foreach ($filelist as $contentFile) { // ContentFile class
+                    $file = $filelistNode->addChild('install');
+                    $file->addAttribute('name', $contentFile->file);
+                    $file->addAttribute('as', $contentFile->installAs);
+                }
+            }
+        } catch (Exception $e) {
+            $logger->error($e->getMessage());
+            exit(1);
+        }
 
 
-		if( class_exists('DOMDocument') ) {
-			$logger->info2("* Re-formating XML...",1);
-			$dom = new \DOMDocument('1.0');
-			$dom->preserveWhiteSpace = false;
-			$dom->formatOutput = true;
-			$dom->loadXML($xml->asXML());
-			return $dom->saveXML();
-		}
-		return $xml->asXML();
+        if (class_exists('DOMDocument')) {
+            $logger->info2("* Re-formating XML...", 1);
+            $dom = new \DOMDocument('1.0');
+            $dom->preserveWhiteSpace = false;
+            $dom->formatOutput = true;
+            $dom->loadXML($xml->asXML());
+            return $dom->saveXML();
+        }
+        return $xml->asXML();
     }
 
-
-	function addPathByRole( $path , $role )
-	{
+    function addPathByRole($path, $role)
+    {
         $list = array();
-		if( is_dir($path) ) {
-			$baseDir = $path;
-			$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($baseDir),
-									RecursiveIteratorIterator::CHILD_FIRST);
-			foreach( $iterator as $path ) {
-				if( $path->isFile() ) {
+        if (is_dir($path)) {
+            $baseDir = $path;
+            $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($baseDir),
+                            RecursiveIteratorIterator::CHILD_FIRST);
+            foreach ($iterator as $path) {
+                if ($path->isFile()) {
                     $filepath = $path->getPathname();
-                    $list[(string) $path] = $this->buildContentFile( $path, $role, $baseDir );
-				}
-			}
-		}
-		else {
-			$files = glob($path);
-			foreach( $files as $filename ) {
-				$fileinfo = new SplFileInfo($filename);
-                $list[(string) $filename] = $this->buildContentFile( $fileinfo , $role );
-			}
-		}
+                    $list[(string) $path] = $this->buildContentFile($path, $role, $baseDir);
+                }
+            }
+        } else {
+            $files = glob($path);
+            foreach ($files as $filename) {
+                $fileinfo = new SplFileInfo($filename);
+                $list[(string) $filename] = $this->buildContentFile($fileinfo, $role);
+            }
+        }
         return $list;
-	}
+    }
 
-    function buildContentFile($fileinfo,$role,$baseDir = '')
+    function buildContentFile($fileinfo, $role, $baseDir = '')
     {
         $filepath = $fileinfo->getPathname();
-        $contentFile = new PackageXml\ContentFile( $filepath );
+        $contentFile = new PackageXml\ContentFile($filepath);
         $contentFile->role = $role;
         $contentFile->md5sum = md5_file($filepath);
 
-        $contentFile->installAs = $filepath;
-        if( $baseDir )
-            $contentFile->installAs = substr( $filepath , strlen($baseDir) + 1 );
+        $contentFile->installAs = basename($filepath);
+        if ($baseDir)
+            $contentFile->installAs = substr($filepath, strlen($baseDir) + 1);
 
-        $this->logger->debug2( sprintf('%s  %-5s  %s', 
-            substr($contentFile->md5sum,0,6),
-            $contentFile->role,
-            $contentFile->file
-        ),1);
+        $this->logger->debug2(sprintf('%s  %-5s  %s', substr($contentFile->md5sum, 0, 6), $contentFile->role, $contentFile->file
+                ), 1);
         return $contentFile;
     }
+
 }
-
-


### PR DESCRIPTION
## 修正一

當系統已經透過 pear 安裝 Onion 時，會使得開發用的 scripts/onion 指令受到干擾。

修正為 scripts/onion 指令只讀取開發用的 Onion 及 vendor 套件。
## 修正二

當 package.ini 設定為：

```
[roles]
bin/my_script = script
```

會使得 my_script 安裝到 bin/bin 資料夾下。

修正為安裝到正確的 bin 資料夾下。
