### PR TITLE
escape backslashes for onion script located in a folder with spaces

### DIFF
--- a/src/Onion/Command/SelfUpdateCommand.php
+++ b/src/Onion/Command/SelfUpdateCommand.php
@@ -16,7 +16,7 @@ class SelfUpdateCommand extends Command
     public function execute($branch = 'master')
     {
         global $argv;
-        $script = realpath( $argv[0] );
+        $script = preg_replace('/ /', '\ ', realpath( $argv[0] ));
         if( ! is_writable($script) ) {
             throw new Exception("$script is not writable.");
         }


### PR DESCRIPTION
HI!
see [issue 29](https://github.com/c9s/Onion/issues/29)
